### PR TITLE
Remove word list container if it already exists

### DIFF
--- a/MemriseUtilities.user.js
+++ b/MemriseUtilities.user.js
@@ -56,6 +56,7 @@ function Main() {
 //Iterate through the levels and kick off the retrieves.
 function SpiderLevels() {
   //Add our UI
+  $('#WordListContainer').remove();
   $("div.container-main").prepend("<div id='WordListContainer'><h2>Working</h2></div>");
   var urls = [];
   if ($("a.level").length > 0) {  


### PR DESCRIPTION
This fixes the problem where the script kept adding new containers every
time the button was pressed. Fixes issue #10 .